### PR TITLE
Add second job label to qb-menu and add support for old qbcore 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,3 +10,9 @@ ALTER TABLE `players`
 ## Dependancies 
 - QBCore 
 - Qb-menu or Renzucontextmenu 
+
+## Updates:
+### v1.0.1:
+- Added a callback to grab the label of job_two allowing you to put that on the menu
+- Added support for old qbcore
+![image](https://media.discordapp.net/attachments/854913681669095454/984098654858117190/unknown.png?width=211&height=107)

--- a/README.MD
+++ b/README.MD
@@ -15,4 +15,5 @@ ALTER TABLE `players`
 ### v1.0.1:
 - Added a callback to grab the label of job_two allowing you to put that on the menu
 - Added support for old qbcore
+##
 ![image](https://media.discordapp.net/attachments/854913681669095454/984098654858117190/unknown.png?width=211&height=107)

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 ## This is a simple Multijob script I made cause too many people were charging $15+ for something so simple.
 ![image](https://i.imgur.com/pwxro0E.png)
-
+Credit: https://github.com/Kmack710/710-multiJob
 ## Add this to your Database! Without this it wont work! Be sure to change payment amount below to the amount of your unemployeed Paycheque 
 ```sql
 ALTER TABLE `players`
@@ -11,7 +11,7 @@ ALTER TABLE `players`
 - QBCore 
 - Qb-menu or Renzucontextmenu 
 
-## Updates:
+## Flek's Updates:
 ### v1.0.1:
 - Added a callback to grab the label of job_two allowing you to put that on the menu
 - Added support for old qbcore

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,11 @@
 Config = {}
 -- ONLY HAVE ONE OF THESE SET TO TRUE!
 Config.usingQBmenu = false -- If you want to use the QB Menu, set this to true.
-Config.usingRenzuContext = true --- If you want to use the Renzu Context Menu, set this to true. https://github.com/renzuzu/renzu_contextmenu
+Config.usingRenzuContext = false --- If you want to use the Renzu Context Menu, set this to true. https://github.com/renzuzu/renzu_contextmenu
 -- ^^^^^^ ONLY HAVE ONE OF THESE SET TO TRUE!
 
-Config.OpenKey = 'NUMPAD9' -- The key to open the menu.
+Config.Core = 'new' -- what qbcore are you using | options allowed: 'old', 'new'
+Cofnig.Open = 'command' -- how do you want to open the multijob menu | options allowed: 'command', 'key'
+Config.OpenKey = 'NUMPAD9' -- The key to open the menu. - only used if Cofnig.Open is set to key
+Config.Command = 'multijob' -- The command to open the menu. - only used if Cofnig.Open is set to command
+Config.MenuHeader = 'Multi Job' -- Header for menu (qb-menu only for this version)

--- a/data/client.lua
+++ b/data/client.lua
@@ -1,22 +1,58 @@
-local QBCore = exports['qb-core']:GetCoreObject()
+-- Variables
 
-RegisterKeyMapping('+changejob', 'Toggle MultiJob Menu', 'keyboard', Config.OpenKey)
+local QBCore = nil
+local job2label = "Unknown"
 
-RegisterCommand('+changejob', function()
-    TriggerEvent('710-multiJob:Client:OpenMenu')
-end)
+-- Grab core object
+
+if Config.Core == 'new' then --new core
+    QBCore = exports['qb-core']:GetCoreObject()
+else --old core
+    Citizen.CreateThread(function()
+        while QBCore == nil do
+            TriggerEvent("QBCore:GetObject", function(obj) QBCore = obj end)
+            Citizen.Wait(10)
+        end
+    end)
+end
+
+-- Register keybind or command
+
+if Cofnig.Open == "key" then
+    RegisterKeyMapping('+changejob', 'Toggle MultiJob Menu', 'keyboard', Config.OpenKey)
+
+    RegisterCommand('+changejob', function()
+        TriggerEvent('710-multiJob:Client:OpenMenu')
+    end)
+else
+    RegisterCommand(Config.Command, function()
+        TriggerEvent('710-multiJob:Client:OpenMenu')
+    end)
+end
+
+-- Events
+
 if Config.usingQBmenu then 
     RegisterNetEvent('710-multiJob:Client:OpenMenu', function()
+        QBCore.Functions.TriggerCallback('710-multiJob:Server:checkjob2', function(results)
+            if not results then
+                TriggerEvent("QBCore:Notify", "Error Fetching Job ", "error")
+                job2label = "Unknown"
+            else
+                job2label = results
+            end
+        end)
+        Wait(1000)
         local Player = QBCore.Functions.GetPlayerData()
         local citizenid = Player.citizenid
         local Menu = {
             {
-                header = "<center><img src=https://i.imgur.com/0SqHk1a.png width=50vh></center><br>Job Changer<br>",
+                header = Config.MenuHeader,
                 isMenuHeader = true
             },
             {
-                header = "Change Jobs".."<br>You are currently working as "..Player.job.label..".<br>",
-                txt = '',
+                header = "Current Job: "..Player.job.label,
+                txt = "Click to change to "..job2label,
                 params = {
                     isServer = true,
                     event = "710-multiJob:Server:ChangeJob",

--- a/data/server.lua
+++ b/data/server.lua
@@ -1,5 +1,16 @@
-local QBCore = exports['qb-core']:GetCoreObject()
+-- Variables
 
+local QBCore = nil
+
+-- Grab core object
+
+if Config.Core == 'new' then --new core
+    QBCore = exports['qb-core']:GetCoreObject()
+else --old core
+    TriggerEvent('QBCore:GetObject', function(obj) QBCore = obj end)
+end
+
+-- Events
 
 RegisterNetEvent('710-multiJob:Server:ChangeJob', function(args)
     local source = source
@@ -22,4 +33,18 @@ RegisterNetEvent('710-multiJob:Server:ChangeJob', function(args)
         --TriggerClientEvent('okokNotify:Alert', source, "Job Changer", "You have changed to your 2nd job "..Job2.label, 5000, 'info') -- if you wanna use OKOK uncomment this :) 
         TriggerClientEvent('QBCore:Notify', source, "You have changed to your 2nd job "..Job2.label, 'primary', 5000)      
     end        
+end)
+
+-- Callbacks
+QBCore.Functions.CreateCallback("710-multiJob:Server:checkjob2", function(source, cb)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    local citizenid = Player.PlayerData.citizenid
+    local result = MySQL.query.await('SELECT job_two FROM players WHERE citizenid = ?',{citizenid})
+    if result[1] then 
+        local secondJobData = json.decode(result[1].job_two)  
+        cb(secondJobData.label) 
+    else 
+        cb(false) 
+    end
 end)


### PR DESCRIPTION
Add more config options
Allow support for new and old qbcore
QB-Menu now displays what the job_two actually is that they are changing to

Demo: (i have different css for my qb-menu but the text will read as):
https://media.discordapp.net/attachments/854913681669095454/984098654858117190/unknown.png?width=211&height=107

